### PR TITLE
hotfix : apply svg Image

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,5 +93,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["src"]
+  "include": ["src", "src/custom.d.ts"]
 }


### PR DESCRIPTION
## 문제상황 및 해결
-  **svg이미지를 import해서 가져왔을 때 해당 모듈을 찾을 수 없음**

>> 정보를 찾아보니 Create-React-App으로 생성한 프로젝트가 아니라면 webpack의 file-loader에 대한 추가설정이 필요한 것 같았습니다.
따라서 아래 참고문헌을 참고하여 추가적으로 설정파일을 입력해 해결하였습니다.
(출처 - https://velog.io/@juno7803/React-React%EC%97%90%EC%84%9C-SVG-%ED%99%9C%EC%9A%A9%ED%95%98%EA%B8%B0 )



- svg이미지 파일을 컴포넌트로 사용하기 위한 추가 설정을 적용하였습니다.
`import { ReactComponent as Banner } from "../assets/images/banner.svg";`

## 참고한문헌
- https://stackoverflow.com/questions/44717164/unable-to-import-svg-files-in-typescript
- https://choi95.tistory.com/206

------


추가로 현재 이미지경로가 public/assets/images로 되어있는데 해당 경로의 이미지를 참고하면 다음과 같은 오류가 발생합니다.
![image](https://user-images.githubusercontent.com/78795820/188685246-badfbdb2-ce8d-412e-b321-2b3b51e413b2.png)

따라서 디렉토리 위치도 src/assets/images로 변경하고 작업해야할 것 같아요.
기존에는 `<img` src = "경로" > `명으로 이미지를 불러왔지만 svg이미지를 가져올때는 import로 이미지 자체를 가져오기때문에? 컴파일 이후에 불러오지 못하므로 src안에 넣어야 한다고 합니다. 관련자료입니다!
https://velog.io/@altjsvnf/React-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EA%B2%BD%EB%A1%9C-%EB%AC%B8%EC%A0%9C